### PR TITLE
[v1.11.x] prov/efa: Fix the mishandling of prefix size when receiving…

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -515,7 +515,7 @@ ssize_t rxr_pkt_copy_to_rx(struct rxr_ep *ep,
 	    rx_entry->cq_entry.len > data_offset && data_size > 0) {
 		bytes_copied = ofi_copy_to_iov(rx_entry->iov,
 					       rx_entry->iov_count,
-					       data_offset,
+					       data_offset + ep->msg_prefix_size,
 					       data,
 					       data_size);
 		if (bytes_copied != MIN(data_size, rx_entry->cq_entry.len - data_offset)) {

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -797,7 +797,7 @@ ssize_t rxr_pkt_proc_matched_read_rtm(struct rxr_ep *ep,
 	/* truncate rx_entry->iov to save memory registration pages because we
 	 * need to do memory registration for the receiving buffer.
 	 */
-	ofi_truncate_iov(rx_entry->iov, &rx_entry->iov_count, rx_entry->total_len);
+	ofi_truncate_iov(rx_entry->iov, &rx_entry->iov_count, rx_entry->total_len + ep->msg_prefix_size);
 	return rxr_read_post_remote_read_or_queue(ep, RXR_RX_ENTRY, rx_entry);
 }
 

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -413,7 +413,7 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 	}
 
 	assert(efa_ep_is_cuda_mr(read_entry->mr_desc[0]));
-	err = ofi_truncate_iov(read_entry->iov, &read_entry->iov_count, data_size);
+	err = ofi_truncate_iov(read_entry->iov, &read_entry->iov_count, data_size + ep->msg_prefix_size);
 	if (err) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
 			"data_offset %ld data_size %ld out of range\n",
@@ -521,7 +521,7 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 	assert(max_read_size > 0);
 
 	ret = rxr_locate_iov_pos(read_entry->iov, read_entry->iov_count,
-				 read_entry->bytes_submitted,
+				 read_entry->bytes_submitted + ep->msg_prefix_size,
 				 &iov_idx, &iov_offset);
 	assert(ret == 0);
 


### PR DESCRIPTION
… data

Currently, the msg prefix size is not included in the offsets
of data copies on the receiver side, which causes data corruptions when
FI_MSG_PREFIX is specified in hint->mode. This patch expands the truncation
size of rx / read entries to include the prefix size, and shift the
offset of local iov accordingly.

Signed-off-by: Shi Jin <sjina@amazon.com>
(cherry picked from commit f6504bc898f21baf4ff8bcb5fbe8ce94788aa3f4)